### PR TITLE
Forgot initialize the platform. Each time when start GC v8 was crashed.

### DIFF
--- a/src/app.cc
+++ b/src/app.cc
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <v8.h>
+#include <include/libplatform/libplatform.h>
+
 
 #ifdef FASTCGI
 #	include <fcgi_stdio.h>
@@ -80,6 +82,10 @@ void TeaJS_App::init() {
 	this->exit_code = 0;
 
 	v8::V8::InitializeICU();
+
+  this->platform = v8::platform::CreateDefaultPlatform();
+  v8::V8::InitializePlatform(this->platform);
+
 	v8::V8::Initialize();
 
 	this->isolate = v8::Isolate::New();

--- a/src/app.h
+++ b/src/app.h
@@ -49,6 +49,9 @@ protected:
 	void setup_teajs(v8::Handle<v8::Object> target);
 
 private:
+	/* current platform */
+	v8::Platform* platform;
+
 	/* current active isolate */
 	v8::Isolate *isolate;
 


### PR DESCRIPTION
Somethings like

```
Program terminated with signal 11, Segmentation fault.
#0  0x0000000000900bc1 in v8::internal::MarkCompactCollector::StartSweeperThreads() ()
(gdb) bt
#0  0x0000000000900bc1 in v8::internal::MarkCompactCollector::StartSweeperThreads() ()
#1  0x000000000090b8c8 in v8::internal::MarkCompactCollector::SweepSpaces() ()
#2  0x000000000091650c in v8::internal::MarkCompactCollector::CollectGarbage() ()
#3  0x00000000008d4796 in v8::internal::Heap::MarkCompact() ()
#4  0x00000000008ddc45 in v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::GCCallbackFlags) ()
#5  0x00000000008de078 in v8::internal::Heap::CollectGarbage(v8::internal::GarbageCollector, char const*, char const*, v8::GCCallbackFlags) ()
#6  0x00000000008de245 in v8::internal::Heap::CollectAllAvailableGarbage(char const*) ()
#7  0x000000000088dce5 in v8::internal::Factory::NewRawTwoByteString(int, v8::internal::PretenureFlag) ()
#8  0x000000000088e3c0 in v8::internal::Factory::NewStringFromUtf8(v8::internal::Vector<char const>, v8::internal::PretenureFlag) ()
#9  0x0000000000749d6c in v8::String::NewFromUtf8(v8::Isolate*, char const*, v8::String::NewStringType, int) ()
#10 0x000000000071b96e in Cache::getScript (this=0x7fff71f70b80, filename=...) at src/cache.cc:168
```
